### PR TITLE
Fixed build on Ubuntu 12.04+.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all: tile
 
 tile: tile.cpp
-	g++ -Wall -o tile -g tile.cpp `pkg-config vipsCC-7.10 --cflags --libs`
+	g++ -Wall -o tile -g tile.cpp `pkg-config vipsCC-7.26 --cflags --libs`

--- a/tile.cpp
+++ b/tile.cpp
@@ -3,6 +3,9 @@
 #include <iostream>
 #include <string>
 #include <sys/time.h>
+#include <stdio.h>      
+#include <string.h>     
+#include <stdlib.h>
 
 using namespace std;
 


### PR DESCRIPTION
Missing header files for stdio, string.h and stdlib.h.
Wrong version of VIPS in Makefile.
